### PR TITLE
fix: typos in enk_extract_linktext / LINKTEXT

### DIFF
--- a/enkoder.php
+++ b/enkoder.php
@@ -143,10 +143,10 @@ $enkoder_plaintext_priority = apply_filters('enkoder_plaintext_priority', 32);
 define("EMAIL_REGEX", '[\w\d+_.-]+@(?:[\w\d_-]+\.)+[\w]{2,6}');
 define("PTEXT_EMAIL", '/(?<=[^\w\d\+_.:-])(' . EMAIL_REGEX . ')/i'); /* note the banned first char */
 define("MAILTO_EMAIL", '#(<a[^<>]*?href=[\'\"]mailto:[^<>]*?>.*?</a>)#i');
-define("LINK_TEXT", "#/>(.*?)</a#i");
+define("LINK_TEXT", "#>(.*?)</a#i");
 
 function enk_extract_linktext($text) {
-  $tmatches = preg_match(LINK_TEXT, $text, $tmatches); //array();
+  preg_match(LINK_TEXT, $text, $tmatches); //array();
   return $tmatches[1];
 }
 


### PR DESCRIPTION
line 146 
define("LINK_TEXT", "#/>(.*?)</a#i");
should be 
define("LINK_TEXT", "#>(.*?)</a#i");

Text that successfully matches MAILTO_EMAIL '#(<a[^<>]*?href=[\'\"]mailto:[^<>]*?>.*?</a>)#i' will not then match LINK_TEXT "#/>(.*?)</a#i" because of an extraneous forward slash (maybe left over from changing the regex delimiter?)

line 149 
$tmatches = preg_match(LINK_TEXT, $text, $tmatches); //array();
should be
preg_match(LINK_TEXT, $text, $tmatches);

The preg_match function will fill the 3rd parameter with the results of search which is what we want, but assigning the return value of the function to $tmatches as well overwrites this with 0 or 1.

fixes #4 